### PR TITLE
Allow running on iOS

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,38 +1,5 @@
-import React, { Component } from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
-
-import { StackNavigator } from 'react-navigation';
-
-import Login from './src/components/login/login';
-import Cadastro from './src/components/cadastro/cadastro';
-import Logout from './src/components/logout/logout';
-import Senha from './src/components/senha/senha';
-import Feed from './src/components/feed/feed';
-import Header from './src/components/feed/header';
-
-const LoginApp = StackNavigator({
-  Login: { screen: Login },
-  Cadastro: { screen: Cadastro },
-  Senha: { screen: Senha },
-  Logout: { screen: Logout },
-  Feed: { screen: Feed },
-  Header: { screen: Header }
-  },
-  {
-    initialRouterName: 'Login',
-    headerMode: 'none',
-  },
-);
-
-export default class loginExample extends Component {
-  render() {
-    return <LoginApp />
-  }
-}
+import React from 'react';
+import { AppRegistry } from 'react-native';
+import loginExample from './src/components/App';
 
 AppRegistry.registerComponent('loginExample', () => loginExample);

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,53 +1,5 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- * @flow
- */
-
-import React, { Component } from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
-
-export default class loginExample extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.ios.js
-        </Text>
-        <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
-        </Text>
-      </View>
-    );
-  }
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
+import React from 'react';
+import { AppRegistry } from 'react-native';
+import loginExample from './src/components/App';
 
 AppRegistry.registerComponent('loginExample', () => loginExample);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import {
+  AppRegistry,
+  StyleSheet,
+  Text,
+  View
+} from 'react-native';
+
+import { StackNavigator } from 'react-navigation';
+
+import Login from './login/login';
+import Cadastro from './cadastro/cadastro';
+import Logout from './logout/logout';
+import Senha from './senha/senha';
+import Feed from './feed/feed';
+import Header from './feed/header';
+
+const LoginApp = StackNavigator({
+  Login: { screen: Login },
+  Cadastro: { screen: Cadastro },
+  Senha: { screen: Senha },
+  Logout: { screen: Logout },
+  Feed: { screen: Feed },
+  Header: { screen: Header }
+},
+  {
+    initialRouterName: 'Login',
+    headerMode: 'none',
+  },
+);
+
+export default class loginExample extends Component {
+  render() {
+    return <LoginApp />
+  }
+}


### PR DESCRIPTION
Hi! I hope this works for what you're wanting. I moved the top-level component code to a single file and then imported that file to both the `index.ios.js` and `index.android.js` files. This achieves two things:

1. The amount of duplicated code is minimized
2. Only one file needs to be modified to make changes

I have verified this runs on the Android emulator as well as the iOS Simulator.